### PR TITLE
Various changes to ‘add character’ dialog

### DIFF
--- a/app/src/main/java/com/lavendergoons/dndcharacter/Dialogs/AddCharacterDialog.java
+++ b/app/src/main/java/com/lavendergoons/dndcharacter/Dialogs/AddCharacterDialog.java
@@ -1,17 +1,14 @@
 package com.lavendergoons.dndcharacter.Dialogs;
 
+import android.annotation.SuppressLint;
 import android.app.Activity;
-import android.content.Context;
 import android.content.DialogInterface;
-import android.support.v4.app.DialogFragment;
 import android.support.v7.app.AlertDialog;
-import android.text.InputType;
-import android.view.ViewGroup;
+import android.view.LayoutInflater;
+import android.view.View;
 import android.widget.EditText;
-import android.widget.LinearLayout;
 import android.widget.Toast;
 
-import com.lavendergoons.dndcharacter.Fragments.CharacterListFragment;
 import com.lavendergoons.dndcharacter.Objects.SimpleCharacter;
 import com.lavendergoons.dndcharacter.R;
 import com.lavendergoons.dndcharacter.Utils.Utils;
@@ -19,65 +16,35 @@ import com.lavendergoons.dndcharacter.Utils.Utils;
 /**
  * Initial simple SimpleCharacter creation dialog.
  */
-public class AddCharacterDialog extends DialogFragment {
+public class AddCharacterDialog {
 
-    private EditText nameEdit, levelEdit;
-    private CharacterListFragment fragment;
-
-    public AddCharacterDialog() {
-        super();
-    }
-
-    public static void showAddCharacterDialog(final Activity activity, final AddCharacterDialog.OnCharacterCompleteListener target) {
+    @SuppressLint("InflateParams")
+    public static void showAddCharacterDialog(final Activity activity, final OnCharacterCompleteListener listener) {
         AlertDialog.Builder builder = new AlertDialog.Builder(activity);
-        LinearLayout dialogLayout = new LinearLayout(activity);
-        LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT);
-        final EditText nameEdit, levelEdit;
 
-        dialogLayout.setOrientation(LinearLayout.VERTICAL);
-        dialogLayout.setLayoutParams(params);
-        dialogLayout.setPadding(2, 2, 2, 2);
+        View rootView = LayoutInflater.from(activity).inflate(R.layout.dialog_add_character, null);
 
-        nameEdit = new EditText(activity);
-        nameEdit.setHint(R.string.hint_name);
-        nameEdit.setInputType(InputType.TYPE_TEXT_FLAG_CAP_WORDS);
-
-        levelEdit = new EditText(activity);
-        levelEdit.setInputType(InputType.TYPE_CLASS_NUMBER);
-        levelEdit.setHint(R.string.hint_level);
-
-        dialogLayout.addView(nameEdit, new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT));
-        dialogLayout.addView(levelEdit, new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT));
+        final EditText nameEdit = (EditText) rootView.findViewById(R.id.nameEdit);
+        final EditText levelEdit = (EditText) rootView.findViewById(R.id.levelEdit);
 
         builder.setTitle(activity.getString(R.string.title_add_character));
-        builder.setView(dialogLayout);
+        builder.setView(rootView);
         builder.setPositiveButton(R.string.ok, new DialogInterface.OnClickListener() {
             @Override
             public void onClick(DialogInterface dialogInterface, int i) {
                 if (!Utils.isStringEmpty(nameEdit.getText().toString()) && !Utils.isStringEmpty(levelEdit.getText().toString())) {
                     SimpleCharacter simpleCharacter = new SimpleCharacter(nameEdit.getText().toString(), Integer.parseInt(levelEdit.getText().toString()));
-                    target.onCharacterComplete(simpleCharacter);
+                    listener.onCharacterComplete(simpleCharacter);
                 } else {
                     Toast.makeText(activity, activity.getString(R.string.warning_enter_required_fields), Toast.LENGTH_LONG).show();
                 }
             }
         }).setNegativeButton(R.string.cancel, null);
 
-        builder.create().show();
+        builder.show();
     }
 
-
-    public static interface OnCharacterCompleteListener {
+    public interface OnCharacterCompleteListener {
         void onCharacterComplete(SimpleCharacter simpleCharacter);
-    }
-
-    @Override
-    public void onAttach(Context context) {
-        super.onAttach(context);
-        try {
-            OnCharacterCompleteListener mListener = (OnCharacterCompleteListener) context;
-        } catch (ClassCastException e) {
-            throw new ClassCastException(context.toString() + " must implement OnCharacterCompleteListener");
-        }
     }
 }

--- a/app/src/main/res/layout/dialog_add_character.xml
+++ b/app/src/main/res/layout/dialog_add_character.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <android.support.design.widget.TextInputLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <EditText
+            android:id="@+id/nameEdit"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/hint_name"
+            android:inputType="textCapWords"/>
+
+    </android.support.design.widget.TextInputLayout>
+
+    <android.support.v4.widget.Space
+        android:layout_width="match_parent"
+        android:layout_height="8dp"/>
+
+    <android.support.design.widget.TextInputLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <EditText
+            android:id="@+id/levelEdit"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/hint_level"
+            android:inputType="number"/>
+    </android.support.design.widget.TextInputLayout>
+
+</LinearLayout>


### PR DESCRIPTION
- Added some more padding around EditText fields, moved from programmatic layouts to xml

- Use TextInputLayout for hint text, because it’s pretty

- AddCharacterDialog no longer implements DialogFragment. Since it’s only shown via the static showAddCharacterDialog() method, we don’t really need it to be a DialogFragment. There was also some code to make sure the parent context object implements the OnCharacterCompleteListener. But, we already ensure this is the case by passing the listener in via the static show() method.

- Removed unused reference to CharacterListFragment

- Remove unnecessary static qualifier for OnCharacterCompleteListener interface

- Call builder.show() instead of builder.create().show() (does the same thing)